### PR TITLE
Fixed dateOnly being not initialized

### DIFF
--- a/lib/datetime_picker_formfield.dart
+++ b/lib/datetime_picker_formfield.dart
@@ -104,7 +104,7 @@ class DateTimePickerFormField extends FormField<DateTime> {
     Key key,
     @required this.format,
     InputType inputType,
-    bool dateOnly,
+    bool dateOnly: false,
     this.editable: true,
     this.onChanged,
     this.resetIcon: Icons.close,


### PR DESCRIPTION
This pr fixes the field `dateOnly` being not initialized or required, which resulted in crashing when it was not provided to the constructor.