### PR TITLE
Update intl

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/jifalops/datetime_picker_formfield
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.15.8
+  intl: ^0.16.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
flutter_driver from current master channel of flutter uses intl@0.16.0, and it prevents using this package along with it.